### PR TITLE
Target commonjs for transpiled output

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,18 +1,7 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
-	preset: "ts-jest/presets/default-esm", // or other ESM presets
-	globals: {
-		"ts-jest": {
-			useESM: true,
-			tsconfig: "tsconfig.test.json"
-		},
-	},
+	preset: "ts-jest",
 	moduleNameMapper: {
 		"^(\\.{1,2}/.*)\\.js$": "$1",
 	},
-	transform: {},
-	setupFilesAfterEnv: [ "./test/prepareTest.ts" ],
-	transformIgnorePatterns: [
-		"node_modules/(?!(@typegoose/typegoose|dotenv|crypto-random-string))"
-	]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "fagc-backend",
 			"version": "2.0.0",
 			"hasInstallScript": true,
 			"license": "ISC",
@@ -16,7 +15,6 @@
 				"@sentry/tracing": "^6.13.3",
 				"@typegoose/typegoose": "^9.2.0",
 				"@types/node": "^16.11.10",
-				"@types/validator": "^13.7.0",
 				"crypto-random-string": "^4.0.0",
 				"debug": "~4.3.3",
 				"discord-oauth2": "^2.8.0",
@@ -41,7 +39,6 @@
 				"openapi3-ts": "^2.0.1",
 				"prom-client": "^14.0.1",
 				"ts-deepmerge": "^1.1.0",
-				"tsc": "^2.0.3",
 				"validator": "^13.7.0",
 				"zod": "^3.11.6"
 			},
@@ -54,6 +51,7 @@
 				"@types/node-fetch": "^3.0.3",
 				"@types/nodemon": "^1.19.1",
 				"@types/prettier": "^2.4.1",
+				"@types/validator": "^13.7.1",
 				"@types/ws": "^7.4.6",
 				"@typescript-eslint/eslint-plugin": "^5.5.0",
 				"@typescript-eslint/parser": "^5.5.0",
@@ -1570,7 +1568,8 @@
 		"node_modules/@types/validator": {
 			"version": "13.7.1",
 			"resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.1.tgz",
-			"integrity": "sha512-I6OUIZ5cYRk5lp14xSOAiXjWrfVoMZVjDuevBYgQDYzZIjsf2CAISpEcXOkFAtpAHbmWIDLcZObejqny/9xq5Q=="
+			"integrity": "sha512-I6OUIZ5cYRk5lp14xSOAiXjWrfVoMZVjDuevBYgQDYzZIjsf2CAISpEcXOkFAtpAHbmWIDLcZObejqny/9xq5Q==",
+			"dev": true
 		},
 		"node_modules/@types/webidl-conversions": {
 			"version": "6.1.1",
@@ -8569,14 +8568,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/tsc": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.3.tgz",
-			"integrity": "sha512-SN+9zBUtrpUcOpaUO7GjkEHgWtf22c7FKbKCA4e858eEM7Qz86rRDpgOU2lBIDf0fLCsEg65ms899UMUIB2+Ow==",
-			"bin": {
-				"tsc": "bin/tsc"
-			}
-		},
 		"node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
@@ -10476,7 +10467,8 @@
 		"@types/validator": {
 			"version": "13.7.1",
 			"resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.1.tgz",
-			"integrity": "sha512-I6OUIZ5cYRk5lp14xSOAiXjWrfVoMZVjDuevBYgQDYzZIjsf2CAISpEcXOkFAtpAHbmWIDLcZObejqny/9xq5Q=="
+			"integrity": "sha512-I6OUIZ5cYRk5lp14xSOAiXjWrfVoMZVjDuevBYgQDYzZIjsf2CAISpEcXOkFAtpAHbmWIDLcZObejqny/9xq5Q==",
+			"dev": true
 		},
 		"@types/webidl-conversions": {
 			"version": "6.1.1",
@@ -15770,11 +15762,6 @@
 					"dev": true
 				}
 			}
-		},
-		"tsc": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/tsc/-/tsc-2.0.3.tgz",
-			"integrity": "sha512-SN+9zBUtrpUcOpaUO7GjkEHgWtf22c7FKbKCA4e858eEM7Qz86rRDpgOU2lBIDf0fLCsEg65ms899UMUIB2+Ow=="
 		},
 		"tslib": {
 			"version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"version": "2.0.0",
 	"private": true,
 	"main": "dist/app.js",
-	"type": "module",
+	"type": "commonjs",
 	"scripts": {
 		"start": "ts-node ./src/app.ts",
 		"dev": "nodemon ./dist/app.ts",
@@ -24,7 +24,6 @@
 		"@sentry/tracing": "^6.13.3",
 		"@typegoose/typegoose": "^9.2.0",
 		"@types/node": "^16.11.10",
-		"@types/validator": "^13.7.0",
 		"crypto-random-string": "^4.0.0",
 		"debug": "~4.3.3",
 		"discord-oauth2": "^2.8.0",
@@ -49,7 +48,6 @@
 		"openapi3-ts": "^2.0.1",
 		"prom-client": "^14.0.1",
 		"ts-deepmerge": "^1.1.0",
-		"tsc": "^2.0.3",
 		"validator": "^13.7.0",
 		"zod": "^3.11.6"
 	},
@@ -73,6 +71,7 @@
 		"@types/node-fetch": "^3.0.3",
 		"@types/nodemon": "^1.19.1",
 		"@types/prettier": "^2.4.1",
+		"@types/validator": "^13.7.1",
 		"@types/ws": "^7.4.6",
 		"@typescript-eslint/eslint-plugin": "^5.5.0",
 		"@typescript-eslint/parser": "^5.5.0",

--- a/src/database/fagc/authentication.ts
+++ b/src/database/fagc/authentication.ts
@@ -1,5 +1,4 @@
-import * as typegoose from "@typegoose/typegoose"
-const { getModelForClass, modelOptions, prop } = typegoose
+import { getModelForClass, modelOptions, prop } from "@typegoose/typegoose"
 
 @modelOptions({
 	schemaOptions: {

--- a/src/database/fagc/community.ts
+++ b/src/database/fagc/community.ts
@@ -1,5 +1,4 @@
-import * as typegoose from "@typegoose/typegoose"
-const { getModelForClass, modelOptions, pre, prop } = typegoose
+import { getModelForClass, modelOptions, pre, prop } from "@typegoose/typegoose"
 import { getUserStringFromID } from "../../utils/functions-databaseless.js"
 
 @modelOptions({

--- a/src/database/fagc/guildconfig.ts
+++ b/src/database/fagc/guildconfig.ts
@@ -1,10 +1,9 @@
-import * as typegoose from "@typegoose/typegoose"
-const {
+import {
 	getModelForClass,
 	modelOptions,
 	Passthrough,
 	prop,
-} = typegoose
+} from "@typegoose/typegoose"
 
 // the thing from https://github.com/oof2win2/fagc-discord-bot/blob/dev/src/database/schemas/config.js
 

--- a/src/database/fagc/log.ts
+++ b/src/database/fagc/log.ts
@@ -1,6 +1,5 @@
 import { getUserStringFromID } from "../../utils/functions-databaseless.js"
-import * as typegoose from "@typegoose/typegoose"
-const { getModelForClass, modelOptions, pre, prop } = typegoose
+import { getModelForClass, modelOptions, pre, prop } from "@typegoose/typegoose"
 
 
 @modelOptions({

--- a/src/database/fagc/report.ts
+++ b/src/database/fagc/report.ts
@@ -1,5 +1,4 @@
-import * as typegoose from "@typegoose/typegoose"
-const { getModelForClass, modelOptions, pre, prop } = typegoose
+import { getModelForClass, modelOptions, pre, prop } from "@typegoose/typegoose"
 import { getUserStringFromID } from "../../utils/functions-databaseless.js"
 
 @modelOptions({

--- a/src/database/fagc/revocation.ts
+++ b/src/database/fagc/revocation.ts
@@ -1,5 +1,4 @@
-import * as typegoose from "@typegoose/typegoose"
-const { getModelForClass, modelOptions, pre, prop } = typegoose
+import { getModelForClass, modelOptions, pre, prop } from "@typegoose/typegoose"
 import { getUserStringFromID } from "../../utils/functions-databaseless.js"
 
 @modelOptions({

--- a/src/database/fagc/rule.ts
+++ b/src/database/fagc/rule.ts
@@ -1,5 +1,4 @@
-import * as typegoose from "@typegoose/typegoose"
-const { getModelForClass, modelOptions, pre, prop } = typegoose
+import { getModelForClass, modelOptions, pre, prop } from "@typegoose/typegoose"
 import { getUserStringFromID } from "../../utils/functions-databaseless.js"
 
 @modelOptions({

--- a/src/database/fagc/user.ts
+++ b/src/database/fagc/user.ts
@@ -1,11 +1,10 @@
-import * as typegoose from "@typegoose/typegoose"
-import { Ref } from "@typegoose/typegoose"
-const {
+import {
 	getModelForClass,
 	modelOptions,
 	pre,
 	prop,
-} = typegoose
+} from "@typegoose/typegoose"
+import { Ref } from "@typegoose/typegoose"
 import { getUserStringFromID } from "../../utils/functions-databaseless.js"
 
 @modelOptions({

--- a/src/database/fagc/webhook.ts
+++ b/src/database/fagc/webhook.ts
@@ -1,5 +1,4 @@
-import * as typegoose from "@typegoose/typegoose"
-const { getModelForClass, modelOptions, prop } = typegoose
+import { getModelForClass, modelOptions, prop } from "@typegoose/typegoose"
 
 @modelOptions({
 	schemaOptions: {

--- a/src/utils/zodOpenAPI.ts
+++ b/src/utils/zodOpenAPI.ts
@@ -1,10 +1,7 @@
 // this is here because the package @anatine/zod-openapi doesnt work properly
 
 import type { SchemaObject } from "openapi3-ts"
-import * as m from "ts-deepmerge"
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-const merge = m.default
+import merge from "ts-deepmerge"
 import { AnyZodObject, z, ZodTypeAny } from "zod"
 
 export interface OpenApiZodAny extends ZodTypeAny {

--- a/test/rules.spec.ts
+++ b/test/rules.spec.ts
@@ -1,11 +1,10 @@
 import RuleModel from "../src/database/fagc/rule"
-import Backend from "./prepareTest.js"
+import backend from "./prepareTest.js"
 
 describe("Rules", () => {
 	it("Should fetch all rules", async () => {
-		jest.setTimeout(30000)
 		const fetchedData = await RuleModel.find({})
-		const response = await Backend.inject({
+		const response = await backend.inject({
 			path: "/rules",
 			method: "GET"
 		})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,13 @@
 {
 	"compilerOptions": {
-		"noEmitHelpers": true,
-		"importHelpers": true,
+		"importHelpers": false,
 		"noImplicitAny": false,
 		"lib": [
 			"esnext",
 			"DOM"
 		],
 		"target": "es2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */,
-		"module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+		"module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
 		"declaration": true /* Generates corresponding '.d.ts' file. */,
 		"declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
 		"sourceMap": true /* Generates corresponding '.map' file. */,

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,3 +1,0 @@
-{
-	"extends": "./tsconfig.json",
-}


### PR DESCRIPTION
There are numerous issues with targeting ES Modules:

Importing TypeScript packages transpiled to commonjs does not behave the
same, most troubeling is that the default export when imported becomes
the module.exports of the transpiled output instead of the default
export declared in the source file.

Jest support for ES Modules is experimental and not usable.  Module
loading does not correctly resolve packages with the "exports" field in
package.json. And loading many modules in parallel with import breaks
the whole instrumentation. The API used by Jest to support ES Modules is
also behind the --experimental-vm-modules flag and not stable.  See
issue 9430 in the jest repositiory for details on the support.

Targeting ES Modules is for these reasons not not practical.